### PR TITLE
fix: csproj path to readme

### DIFF
--- a/Source/TeleCore/src/TeleCore/TeleCore.csproj
+++ b/Source/TeleCore/src/TeleCore/TeleCore.csproj
@@ -45,7 +45,7 @@
 
     <ItemGroup>
         <None Include="LICENSE.md" Pack="true" PackagePath=""/>
-        <None Include="..\..\README.md" Pack="true" PackagePath=""/>
+        <None Include="..\..\..\..\README.md" Pack="true" PackagePath=""/>
         <None Remove="NodeEditorFramework\**"/>
         <None Remove="Root\Systems\FlowCore\Containers\**" />
     </ItemGroup>


### PR DESCRIPTION
Due to a project restructuring, the csproj's path to README.md is incorrect. We needed to step two further directory upwards.